### PR TITLE
Avoid Player Counter displaying "undefined"

### DIFF
--- a/resources/hubstats.js
+++ b/resources/hubstats.js
@@ -43,6 +43,7 @@ function setRoomListeners(roomSocket, roomName){
       //let roomHost = message.data.roomHost
       //let roomId = message.data.roomId
       roomState = message.data.roomState
+      playersNum = message.data.players;
       //let selectedDifficulty = message.data.selectedDifficulty
       if(message.data.selectedSong){
         songName = message.data.selectedSong.songName


### PR DESCRIPTION
As ``UpdatePlayerInfo`` is not sent when a room is empty, ``playersNum`` may be ``undefined`` and display incorrectly for the user.
``GetRoomInfo`` is always sent and includes the player Number at 0 correctly and thus can be used to set the variable correctly.